### PR TITLE
clang constant conversion warning fix

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -843,7 +843,7 @@ namespace uuids
 
       long long get_time_intervals()
       {
-         auto start = std::chrono::system_clock::from_time_t(-12219292800);
+         auto start = std::chrono::system_clock::from_time_t(time_t(-12219292800));
          auto diff = std::chrono::system_clock::now() - start;
          auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(diff).count();
          return ns / 100;


### PR DESCRIPTION
error : implicit conversion from 'long long' to 'time_t' (aka 'long') changes value from -12219292800 to 665609088 [-Werror,-Wconstant-conversion]