### PR TITLE
Remove Windows dependency (disable uuid_time_generator by default)

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <span>
 
+#if defined(UUID_TIME_GENERATOR) || defined(UUID_SYSTEM_GENERATOR)
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -46,6 +47,7 @@
 #include <CoreFoundation/CFUUID.h>
 #endif
 
+#endif
 #endif
 
 namespace uuids
@@ -843,6 +845,7 @@ namespace uuids
       detail::sha1 hasher;
    };
 
+#ifdef UUID_TIME_GENERATOR
    // !!! DO NOT USE THIS IN PRODUCTION
    // this implementation is unreliable for good uuids
    class uuid_time_generator
@@ -924,6 +927,7 @@ namespace uuids
          return {};
       }
    };
+#endif
 }
 
 namespace std


### PR DESCRIPTION
This PR disables uuid_time_generator by default, allowing it to be re-enabled by defining UUID_TIME_GENERATOR.

If neither UUID_TIME_GENERATOR or UUID_SYSTEM_GENERATOR are included, Windows.h will not be included.  This avoids some namespace trouble and compile-time overhead.

I was originally planning to add a disable macro rather than an enable macro, but noticed the warning in the source against using uuid_time_generator in production.  Nevertheless, this might break compatibility with some existing projects.