### PR TITLE
Support string_view parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: cpp
 compiler: gcc
-dist: trusty
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cppcheck
+      - g++-8
+      - uuid-dev
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
   - sudo apt-cache search libuuid
 
 install: 
-  - sudo apt-get install -qq g++-8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
-  - sudo apt-get install -qq cppcheck
-  - sudo apt-get install uuid-dev
   
 before_script:
   - cd ${TRAVIS_BUILD_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
-  - cmake -H. -BBuild -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Wdev
+  - cmake -H. -BBuild -DCMAKE_BUILD_TYPE=Release -Wdev
   - cd Build
   
 script:

--- a/include/uuid.h
+++ b/include/uuid.h
@@ -513,14 +513,6 @@ namespace uuids
          return uuid{ data };
       }
 
-      template<class CharT = char, 
-               class Traits = std::char_traits<CharT>,
-               class Allocator = std::allocator<CharT>>
-      static std::optional<uuid> from_string(std::basic_string<CharT, Traits, Allocator> const & str) noexcept
-      {
-         return from_string(str.c_str());
-      }
-
    private:
       std::array<value_type, 16> data{ { 0 } };
 

--- a/test/test_generators.cpp
+++ b/test/test_generators.cpp
@@ -254,6 +254,49 @@ TEST_CASE("Test name generator (std::string)", "[gen][name]")
    REQUIRE(id3 != id4);
 }
 
+TEST_CASE("Test name generator (std::string_view)", "[gen][name]")
+{
+   using namespace std::string_view_literals;
+
+   uuids::uuid_name_generator dgen(uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43").value());
+   auto id1 = dgen("john"sv);
+   REQUIRE(!id1.is_nil());
+   REQUIRE(id1.version() == uuids::uuid_version::name_based_sha1);
+   REQUIRE(id1.variant() == uuids::uuid_variant::rfc);
+
+   auto id2 = dgen("jane"sv);
+   REQUIRE(!id2.is_nil());
+   REQUIRE(id2.version() == uuids::uuid_version::name_based_sha1);
+   REQUIRE(id2.variant() == uuids::uuid_variant::rfc);
+
+   auto id3 = dgen("jane"sv);
+   REQUIRE(!id3.is_nil());
+   REQUIRE(id3.version() == uuids::uuid_version::name_based_sha1);
+   REQUIRE(id3.variant() == uuids::uuid_variant::rfc);
+
+   auto id4 = dgen(L"jane"sv);
+   REQUIRE(!id4.is_nil());
+   REQUIRE(id4.version() == uuids::uuid_version::name_based_sha1);
+   REQUIRE(id4.variant() == uuids::uuid_variant::rfc);
+
+   REQUIRE(id1 != id2);
+   REQUIRE(id2 == id3);
+   REQUIRE(id3 != id4);
+}
+
+TEST_CASE("Test name generator equality (char const*, std::string, std::string_view)", "[gen][name]")
+{
+   using namespace std::literals;
+
+   uuids::uuid_name_generator dgen(uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43").value());
+   auto id1 = dgen("john");
+   auto id2 = dgen("john"s);
+   auto id3 = dgen("john"sv);
+
+   REQUIRE(id1 == id2);
+   REQUIRE(id2 == id3);
+}
+
 #ifdef _WIN32
 TEST_CASE("Test time generator", "[gen][time]")
 {

--- a/test/test_uuid.cpp
+++ b/test/test_uuid.cpp
@@ -100,6 +100,20 @@ TEST_CASE("Test is_valid_uuid(basic_string)", "[parse]")
    }
 }
 
+TEST_CASE("Test is_valid_uuid(basic_string_view)", "[parse]")
+{
+   using namespace std::string_view_literals;
+
+   REQUIRE(uuids::uuid::is_valid_uuid("47183823-2574-4bfd-b411-99ed177d3e43"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid("{47183823-2574-4bfd-b411-99ed177d3e43}"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid(L"47183823-2574-4bfd-b411-99ed177d3e43"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid(L"{47183823-2574-4bfd-b411-99ed177d3e43}"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid("00000000-0000-0000-0000-000000000000"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid("{00000000-0000-0000-0000-000000000000}"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid(L"00000000-0000-0000-0000-000000000000"sv));
+   REQUIRE(uuids::uuid::is_valid_uuid(L"{00000000-0000-0000-0000-000000000000}"sv));
+}
+
 TEST_CASE("Test is_valid_uuid(char*) invalid format", "[parse]")
 {
    REQUIRE(!uuids::uuid::is_valid_uuid(""));
@@ -143,6 +157,18 @@ TEST_CASE("Test is_valid_uuid(basic_string) invalid format", "[parse]")
       auto str = "47183823-2574-4bfd-b411-99ed177d3e43}"s;
       REQUIRE(!uuids::uuid::is_valid_uuid(str));
    }
+}
+
+TEST_CASE("Test is_valid_uuid(basic_string_view) invalid format", "[parse]")
+{
+   using namespace std::string_view_literals;
+
+   REQUIRE(!uuids::uuid::is_valid_uuid(""sv));
+   REQUIRE(!uuids::uuid::is_valid_uuid("{}"sv));
+   REQUIRE(!uuids::uuid::is_valid_uuid("47183823-2574-4bfd-b411-99ed177d3e4"sv));
+   REQUIRE(!uuids::uuid::is_valid_uuid("47183823-2574-4bfd-b411-99ed177d3e430"sv));
+   REQUIRE(!uuids::uuid::is_valid_uuid("{47183823-2574-4bfd-b411-99ed177d3e43"sv));
+   REQUIRE(!uuids::uuid::is_valid_uuid("47183823-2574-4bfd-b411-99ed177d3e43}"sv));
 }
 
 TEST_CASE("Test from_string(char*)", "[parse]")
@@ -219,7 +245,7 @@ TEST_CASE("Test from_string(basic_string)", "[parse]")
    }
 
    {
-      auto guid = uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43").value();
+      auto guid = uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43"s).value();
       REQUIRE(uuids::to_string(guid) == "47183823-2574-4bfd-b411-99ed177d3e43");
       REQUIRE(uuids::to_string<wchar_t>(guid) == L"47183823-2574-4bfd-b411-99ed177d3e43");
    }
@@ -256,6 +282,65 @@ TEST_CASE("Test from_string(basic_string)", "[parse]")
 
    {
       auto str = L"{00000000-0000-0000-0000-000000000000}"s;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(guid.is_nil());
+   }
+}
+
+TEST_CASE("Test from_string(basic_string_view)", "[parse]")
+{
+   using namespace std::string_view_literals;
+
+   {
+      auto str = "47183823-2574-4bfd-b411-99ed177d3e43"sv;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(uuids::to_string(guid) == str);
+   }
+
+   {
+      auto str = "{47183823-2574-4bfd-b411-99ed177d3e43}"sv;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(uuids::to_string(guid) == "47183823-2574-4bfd-b411-99ed177d3e43");
+   }
+
+   {
+      auto guid = uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43"sv).value();
+      REQUIRE(uuids::to_string(guid) == "47183823-2574-4bfd-b411-99ed177d3e43");
+      REQUIRE(uuids::to_string<wchar_t>(guid) == L"47183823-2574-4bfd-b411-99ed177d3e43");
+   }
+
+   {
+      auto str = L"47183823-2574-4bfd-b411-99ed177d3e43"sv;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(uuids::to_string<wchar_t>(guid) == str);
+   }
+
+   {
+      auto str = "4718382325744bfdb41199ed177d3e43"sv;
+      REQUIRE_NOTHROW(uuids::uuid::from_string(str));
+      REQUIRE(uuids::uuid::from_string(str).has_value());
+   }
+
+   {
+      auto str = "00000000-0000-0000-0000-000000000000"sv;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(guid.is_nil());
+   }
+
+   {
+      auto str = "{00000000-0000-0000-0000-000000000000}"sv;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(guid.is_nil());
+   }
+
+   {
+      auto str = L"00000000-0000-0000-0000-000000000000"sv;
+      auto guid = uuids::uuid::from_string(str).value();
+      REQUIRE(guid.is_nil());
+   }
+
+   {
+      auto str = L"{00000000-0000-0000-0000-000000000000}"sv;
       auto guid = uuids::uuid::from_string(str).value();
       REQUIRE(guid.is_nil());
    }
@@ -304,6 +389,18 @@ TEST_CASE("Test from_string(basic_string) invalid format", "[parse]")
       auto str = "47183823-2574-4bfd-b411-99ed177d3e43}"s;
       REQUIRE(!uuids::uuid::from_string(str).has_value());
    }
+}
+
+TEST_CASE("Test from_string(basic_string_view) invalid format", "[parse]")
+{
+   using namespace std::string_view_literals;
+
+   REQUIRE(!uuids::uuid::from_string(""sv).has_value());
+   REQUIRE(!uuids::uuid::from_string("{}"sv).has_value());
+   REQUIRE(!uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e4"sv).has_value());
+   REQUIRE(!uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e430"sv).has_value());
+   REQUIRE(!uuids::uuid::from_string("{47183823-2574-4bfd-b411-99ed177d3e43"sv).has_value());
+   REQUIRE(!uuids::uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43}"sv).has_value());
 }
 
 TEST_CASE("Test iterators constructor", "[ctors]")

--- a/test/test_uuid.cpp
+++ b/test/test_uuid.cpp
@@ -346,6 +346,14 @@ TEST_CASE("Test from_string(basic_string_view)", "[parse]")
    }
 }
 
+TEST_CASE("Test constexpr from_string", "[const]")
+{
+   constexpr uuid value = uuid::from_string("47183823-2574-4bfd-b411-99ed177d3e43").value();
+   static_assert(!value.is_nil());
+   static_assert(value.variant() == uuid_variant::rfc);
+   static_assert(value.version() != uuid_version::none);
+}
+
 TEST_CASE("Test from_string(char*) invalid format", "[parse]")
 {
    REQUIRE(!uuids::uuid::from_string("").has_value());
@@ -560,9 +568,9 @@ TEST_CASE("Test swap", "[ops]")
 TEST_CASE("Test constexpr", "[const]")
 {
    constexpr uuid empty;
-   [[maybe_unused]] constexpr bool isnil = empty.is_nil();
-   [[maybe_unused]] constexpr uuids::uuid_variant variant = empty.variant();
-   [[maybe_unused]] constexpr uuid_version version = empty.version();
+   static_assert(empty.is_nil());
+   static_assert(empty.variant() == uuid_variant::ncs);
+   static_assert(empty.version() == uuid_version::none);
 }
 
 TEST_CASE("Test size", "[operators]")


### PR DESCRIPTION
Fixes #20.
Fixes #25.

- uuid::is_valid_uuid
- uuid::from_string
- uuid_name_generator::operator()

Add string_view test cases for each.
Add compile-time tests for constexpr constructor and from_string.

*Note API breaking change*: explicit template parameters need to be changed for these functions. Eg. `uuid::is_valid_uuid<char>("{}")` needs to be updated to `uuid::is_valid_uuid<char const *>("{}")` or simply deduced `uuid::is_valid_uuid("{}")`.