### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,23 +3,20 @@ version: '{build}'
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
-      FLAGS: ""
-      GENERATOR: Visual Studio 15 2017
+      CMAKE_GENERATOR: Visual Studio 15 2017
+      CMAKE_GENERATOR_PLATFORM: Win32
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      FLAGS: ""
-      GENERATOR: Visual Studio 15 2017
+      CMAKE_GENERATOR: Visual Studio 15 2017
+      CMAKE_GENERATOR_PLATFORM: x64
 
 init:
   - cmake --version
   - msbuild /version
 
 before_build:
-  - mkdir build
+  - cmake -S . -B build
   - cd build
-  - cmake .. -G "%GENERATOR%" -DBUILD_TESTS=ON -DCMAKE_CXX_FLAGS="%FLAGS%" -DCMAKE_IGNORE_PATH="C:/Program Files/Git/usr/bin"
 
 build_script:
   - cmake --build . --config Release

--- a/test/test_generators.cpp
+++ b/test/test_generators.cpp
@@ -297,7 +297,7 @@ TEST_CASE("Test name generator equality (char const*, std::string, std::string_v
    REQUIRE(id2 == id3);
 }
 
-#ifdef _WIN32
+#ifdef UUID_TIME_GENERATOR
 TEST_CASE("Test time generator", "[gen][time]")
 {
    uuid_time_generator gen;


### PR DESCRIPTION
- UUID_TIME_GENERATOR macro guard for uuid_time_generator tests
- Update AppVeyor configuration to build x64 architecture correctly.