### PR TITLE
Enable generator tests on Windows CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 option(UUID_BUILD_TESTS "Build the unit tests" ON)
 option(UUID_SYSTEM_GENERATOR "Enable operating system uuid generator" OFF)
+option(UUID_TIME_GENERATOR "Enable experimental time-based uuid generator" OFF)
 option(UUID_USING_CXX20_SPAN "Using span from std instead of gsl" OFF)
 
 # Library target
@@ -28,6 +29,11 @@ if (UUID_SYSTEM_GENERATOR)
         endif ()
     endif ()
 endif ()
+
+# Using time-based generator
+if (UUID_TIME_GENERATOR)
+    target_compile_definitions(${PROJECT_NAME} INTERFACE UUID_TIME_GENERATOR)
+endif()
 
 # Using span from std
 if (NOT UUID_USING_CXX20_SPAN)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,14 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017
       CMAKE_GENERATOR_PLATFORM: x64
+      CMAKE_CLI_FLAGS: -DUUID_SYSTEM_GENERATOR=ON -DUUID_TIME_GENERATOR=ON
 
 init:
   - cmake --version
   - msbuild /version
 
 before_build:
-  - cmake -S . -B build
+  - cmake %CMAKE_CLI_FLAGS% -S . -B build
   - cd build
 
 build_script:

--- a/include/uuid.h
+++ b/include/uuid.h
@@ -835,11 +835,11 @@ namespace uuids
          return ns / 100;
       }
 
-      static short get_clock_sequence()
+      static unsigned short get_clock_sequence()
       {
          static std::mt19937 clock_gen(std::random_device{}());
-         static std::uniform_int_distribution<short> clock_dis{ -32768, 32767 };
-         static std::atomic_short clock_sequence = clock_dis(clock_gen);
+         static std::uniform_int_distribution<unsigned short> clock_dis;
+         static std::atomic_ushort clock_sequence = clock_dis(clock_gen);
          return clock_sequence++;
       }
 
@@ -852,7 +852,7 @@ namespace uuids
 
             auto tm = get_time_intervals();
 
-            short clock_seq = get_clock_sequence();
+            auto clock_seq = get_clock_sequence();
 
             auto ptm = reinterpret_cast<uuids::uuid::value_type*>(&tm);
 
@@ -860,7 +860,7 @@ namespace uuids
             memcpy(&data[4], ptm + 2, 2);
             memcpy(&data[6], ptm, 2);
 
-            memcpy(&data[8], reinterpret_cast<uuids::uuid::value_type*>(&clock_seq), 2);
+            memcpy(&data[8], &clock_seq, 2);
 
             // variant must be 0b10xxxxxx
             data[8] &= 0xBF;


### PR DESCRIPTION
- Reduce included windows headers
- Reduce scope of time-generator dependencies
- Fix version for time-based generated UUID