### PR TITLE
Fix operator<< compiler error when c++20 enabled

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -550,13 +550,6 @@ namespace uuids
       return lhs.data < rhs.data;
    }
 
-   template <class Elem, class Traits>
-   std::basic_ostream<Elem, Traits> & operator<<(std::basic_ostream<Elem, Traits> &s, uuid const & id)
-   {
-      s << to_string(id);
-      return s;
-   }
-
    template<class CharT = char,
             class Traits = std::char_traits<CharT>,
             class Allocator = std::allocator<CharT>>
@@ -576,6 +569,13 @@ namespace uuids
       }
 
       return uustr;
+   }
+
+   template <class Elem, class Traits>
+   std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& s, uuid const& id)
+   {
+       s << to_string(id);
+       return s;
    }
 
    inline void swap(uuids::uuid & lhs, uuids::uuid & rhs) noexcept


### PR DESCRIPTION
Identified compilation error while attempting to use latest version of library within project that uses C++20

Recreated error while compiling tests with UUID_USING_CXX20_SPAN switched on.

Problem appears to be due to prior change to operator<< to use to_string, which is currently defined after operator<< and it would seem C++20 is stricter in this regard (or at least MSVC is).  Fixed by moving operator<< below to_string implementation.