### PR TITLE
Restored Windows related defines

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -19,6 +19,13 @@
 
 #ifdef _WIN32
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #ifdef UUID_SYSTEM_GENERATOR
 #include <objbase.h>
 #endif


### PR DESCRIPTION
Restored Windows related defines, which were removed in commit 4959d46. These are still needed even if fewer Windows headers are included to avoid conflicts during compilation. 
