### PR TITLE
Added Appropriate nodiscards

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -62,7 +62,7 @@ namespace uuids
    namespace detail
    {
       template <typename TChar>
-      constexpr inline unsigned char hex2char(TChar const ch)
+      [[nodiscard]] constexpr inline unsigned char hex2char(TChar const ch)
       {
          if (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9'))
             return static_cast<unsigned char>(ch - static_cast<TChar>('0'));
@@ -74,7 +74,7 @@ namespace uuids
       }
 
       template <typename TChar>
-      constexpr inline bool is_hex(TChar const ch)
+      [[nodiscard]] constexpr inline bool is_hex(TChar const ch)
       {
          return
             (ch >= static_cast<TChar>('0') && ch <= static_cast<TChar>('9')) ||
@@ -83,13 +83,14 @@ namespace uuids
       }
 
       template <typename TChar>
-      constexpr std::basic_string_view<TChar> to_string_view(TChar const * str)
+      [[nodiscard]] constexpr std::basic_string_view<TChar> to_string_view(TChar const * str)
       {
          if (str) return str;
          return {};
       }
 
       template <typename StringType>
+	  [[nodiscard]] 
       constexpr std::basic_string_view<
          typename StringType::value_type,
          typename StringType::traits_type>
@@ -106,7 +107,7 @@ namespace uuids
 
          static constexpr unsigned int block_bytes = 64;
 
-         inline static uint32_t left_rotate(uint32_t value, size_t const count) 
+         [[nodiscard]] inline static uint32_t left_rotate(uint32_t value, size_t const count) 
          {
             return (value << count) ^ (value >> (32 - count));
          }
@@ -395,7 +396,7 @@ namespace uuids
             std::copy(first, last, std::begin(data));
       }
       
-      constexpr uuid_variant variant() const noexcept
+      [[nodiscard]] constexpr uuid_variant variant() const noexcept
       {
          if ((data[8] & 0x80) == 0x00)
             return uuid_variant::ncs;
@@ -407,7 +408,7 @@ namespace uuids
             return uuid_variant::reserved;
       }
 
-      constexpr uuid_version version() const noexcept
+      [[nodiscard]] constexpr uuid_version version() const noexcept
       {
          if ((data[6] & 0xF0) == 0x10)
             return uuid_version::time_based;
@@ -423,7 +424,7 @@ namespace uuids
             return uuid_version::none;
       }
 
-      constexpr bool is_nil() const noexcept
+      [[nodiscard]] constexpr bool is_nil() const noexcept
       {
          for (size_t i = 0; i < data.size(); ++i) if (data[i] != 0) return false;
          return true;
@@ -434,13 +435,13 @@ namespace uuids
          data.swap(other.data);
       }
 
-      inline span<std::byte const, 16> as_bytes() const
+      [[nodiscard]] inline span<std::byte const, 16> as_bytes() const
       {
          return span<std::byte const, 16>(reinterpret_cast<std::byte const*>(data.data()), 16);
       }
 
       template <typename StringType>
-      constexpr static bool is_valid_uuid(StringType const & in_str) noexcept
+      [[nodiscard]] constexpr static bool is_valid_uuid(StringType const & in_str) noexcept
       {
          auto str = detail::to_string_view(in_str);
          bool firstDigit = true;
@@ -484,7 +485,7 @@ namespace uuids
       }
 
       template <typename StringType>
-      constexpr static std::optional<uuid> from_string(StringType const & in_str) noexcept
+      [[nodiscard]] constexpr static std::optional<uuid> from_string(StringType const & in_str) noexcept
       {
          auto str = detail::to_string_view(in_str);
          bool firstDigit = true;
@@ -549,17 +550,17 @@ namespace uuids
    // operators and non-member functions
    // --------------------------------------------------------------------------------------------------------------------------
 
-   inline bool operator== (uuid const& lhs, uuid const& rhs) noexcept
+   [[nodiscard]] inline bool operator== (uuid const& lhs, uuid const& rhs) noexcept
    {
       return lhs.data == rhs.data;
    }
 
-   inline bool operator!= (uuid const& lhs, uuid const& rhs) noexcept
+   [[nodiscard]] inline bool operator!= (uuid const& lhs, uuid const& rhs) noexcept
    {
       return !(lhs == rhs);
    }
 
-   inline bool operator< (uuid const& lhs, uuid const& rhs) noexcept
+   [[nodiscard]] inline bool operator< (uuid const& lhs, uuid const& rhs) noexcept
    {
       return lhs.data < rhs.data;
    }
@@ -567,7 +568,7 @@ namespace uuids
    template <class CharT,
              class Traits,
              class Allocator>
-   inline std::basic_string<CharT, Traits, Allocator> to_string(uuid const & id)
+   [[nodiscard]] inline std::basic_string<CharT, Traits, Allocator> to_string(uuid const & id)
    {
       std::basic_string<CharT, Traits, Allocator> uustr{detail::empty_guid<CharT>};
 
@@ -730,7 +731,7 @@ namespace uuids
       explicit basic_uuid_random_generator(engine_type* gen) :
          generator(gen, [](auto) {}) {}
 
-      uuid operator()()
+      [[nodiscard]] uuid operator()()
       {
          uint8_t bytes[16];
          for (int i = 0; i < 16; i += 4)
@@ -762,7 +763,7 @@ namespace uuids
       {}
 
       template <typename StringType>
-      uuid operator()(StringType const & name)
+      [[nodiscard]] uuid operator()(StringType const & name)
       {
          reset();
          process_characters(detail::to_string_view(name));
@@ -794,7 +795,7 @@ namespace uuids
          }
       }
 
-      uuid make_uuid()
+      [[nodiscard]] uuid make_uuid()
       {
          detail::sha1::digest8_t digest;
          hasher.get_digest_bytes(digest);
@@ -824,7 +825,7 @@ namespace uuids
 
       std::optional<mac_address> device_address;
 
-      bool get_mac_address()
+      [[nodiscard]] bool get_mac_address()
       {         
          if (device_address.has_value())
          {
@@ -847,7 +848,7 @@ namespace uuids
          return device_address.has_value();
       }
 
-      long long get_time_intervals()
+      [[nodiscard]] long long get_time_intervals()
       {
          auto start = std::chrono::system_clock::from_time_t(time_t(-12219292800));
          auto diff = std::chrono::system_clock::now() - start;
@@ -855,7 +856,7 @@ namespace uuids
          return ns / 100;
       }
 
-      static unsigned short get_clock_sequence()
+      [[nodiscard]] static unsigned short get_clock_sequence()
       {
          static std::mt19937 clock_gen(std::random_device{}());
          static std::uniform_int_distribution<unsigned short> clock_dis;
@@ -864,7 +865,7 @@ namespace uuids
       }
 
    public:
-      uuid operator()()
+      [[nodiscard]] uuid operator()()
       {
          if (get_mac_address())
          {
@@ -909,7 +910,7 @@ namespace std
       using argument_type = uuids::uuid;
       using result_type   = std::size_t;
 
-      result_type operator()(argument_type const &uuid) const
+      [[nodiscard]] result_type operator()(argument_type const &uuid) const
       {
 #ifdef UUID_HASH_STRING_BASED
          std::hash<std::string> hasher;


### PR DESCRIPTION
Hey I was using the library and accidentally perform an error with `uuid::from_string` function. I would have caught the error if the function was `[[nodiscard]]`. So I added `[[nodiscard]]` to all functions that seemed appropriate. 

I didn't add it to the random generator function because for some reason someone may just want to cycle random numbers out of no where. Don't really know why, but I wasn't 100% sure so I didn't add it there. 

I also may have horribly messed up the spacing on things. Apologies, I have class in 10 minutes and I will definitely forget about this entire thing by the end of it. 