### PR TITLE
I believe this fixes an alignment issue.

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -732,7 +732,7 @@ namespace uuids
 
       uuid operator()()
       {
-         uint8_t bytes[16];
+         alignas(uint32_t) uint8_t bytes[16];
          for (int i = 0; i < 16; i += 4)
             *reinterpret_cast<uint32_t*>(bytes + i) = distribution(*generator);
 


### PR DESCRIPTION
I believe the second issue referenced in #27 is due to the fact that the bytes array is casted to a `uint32_t *`, which may cause an alignment issue. So this should force the compiler to align it as if it were a `uint32_t` array.