### PR TITLE
Optional install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.7.0)
+
+set(UUID_MAIN_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(UUID_MAIN_PROJECT ON)
+endif()
+
 project(stduuid CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -6,6 +12,7 @@ option(UUID_BUILD_TESTS "Build the unit tests" ON)
 option(UUID_SYSTEM_GENERATOR "Enable operating system uuid generator" OFF)
 option(UUID_TIME_GENERATOR "Enable experimental time-based uuid generator" OFF)
 option(UUID_USING_CXX20_SPAN "Using span from std instead of gsl" OFF)
+option(UUID_ENABLE_INSTALL "Create an install target" ${UUID_MAIN_PROJECT})
 
 # Library target
 add_library(${PROJECT_NAME} INTERFACE)
@@ -40,31 +47,35 @@ if (NOT UUID_USING_CXX20_SPAN)
     target_include_directories(${PROJECT_NAME} INTERFACE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gsl>
             $<INSTALL_INTERFACE:include/gsl>)
-    install(DIRECTORY gsl DESTINATION include)
+    if(UUID_ENABLE_INSTALL)
+        install(DIRECTORY gsl DESTINATION include)
+    endif()
 endif ()
 
-# Install step and imported target
-install(FILES include/uuid.h DESTINATION include)
-install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets)
-install(EXPORT ${PROJECT_NAME}-targets
-        DESTINATION lib/cmake/${PROJECT_NAME})
+if(UUID_ENABLE_INSTALL)
+    # Install step and imported target
+    install(FILES include/uuid.h DESTINATION include)
+    install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets)
+    install(EXPORT ${PROJECT_NAME}-targets
+            DESTINATION lib/cmake/${PROJECT_NAME})
 
-# Config files for find_package()
-include(CMakePackageConfigHelpers)
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-        INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
-write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
-        VERSION "1.0"
-        COMPATIBILITY AnyNewerVersion)
-install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
-        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibuuid.cmake"
-        DESTINATION lib/cmake/${PROJECT_NAME})
-export(EXPORT ${PROJECT_NAME}-targets
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-targets.cmake")
+    # Config files for find_package()
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+            INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+    write_basic_package_version_file(
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
+            VERSION "1.0"
+            COMPATIBILITY AnyNewerVersion)
+    install(FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
+            "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibuuid.cmake"
+            DESTINATION lib/cmake/${PROJECT_NAME})
+    export(EXPORT ${PROJECT_NAME}-targets
+            FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-targets.cmake")
+endif()
 
 # Tests
 if (UUID_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(stduuid CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
-option(UUID_BUILD_TESTS "Build the unit tests" ON)
+option(UUID_BUILD_TESTS "Build the unit tests" ${UUID_MAIN_PROJECT})
 option(UUID_SYSTEM_GENERATOR "Enable operating system uuid generator" OFF)
 option(UUID_TIME_GENERATOR "Enable experimental time-based uuid generator" OFF)
 option(UUID_USING_CXX20_SPAN "Using span from std instead of gsl" OFF)


### PR DESCRIPTION
Hi, I introduced a `UUID_ENABLE_INSTALL` to make installation of the library optional during the CMake config stage.
It is enabled by default when building the project as a main project, but is disabled by default when using something like `add_subdirectory`, `FetchContent`, `CPM`, etc...
I also added in separate commit the same behavior for unit test.
This is useful to disable installation if for example I'm creating a shared library that use stduuid as a private header. I don't want it to be installed along with my library.
Have a nice day, thanks for all the work :)