### PR TITLE
Only use embedded GSL if there is no target "GSL"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (UUID_TIME_GENERATOR)
 endif()
 
 # Using span from std
-if (NOT UUID_USING_CXX20_SPAN)
+if (NOT UUID_USING_CXX20_SPAN AND NOT TARGET GSL)
     target_include_directories(${PROJECT_NAME} INTERFACE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
             $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
When using stduuid with FetchContent/CPM.cmake/find_package, and also including GSL with such process, it create a conflict and it then become ambiguous which file is used where.
Concrete use case:
```cmake
CPMAddPackage(
  NAME GSL
  GIT_REPOSITORY "https://github.com/microsoft/GSL"
  GIT_TAG "v4.0.0"
)
CPMAddPackage(
  NAME stduuid
  GIT_REPOSITORY "https://github.com/mariusbancila/stduuid"
  GIT_TAG "master"
)
```

For now the workaround is to defined `UUID_USING_CXX20_SPAN `, which defeat its meaning.