### PR TITLE
Install header to a dedicated directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif ()
 
 if(UUID_ENABLE_INSTALL)
     # Install step and imported target
-    install(FILES include/uuid.h DESTINATION include)
+    install(FILES include/uuid.h DESTINATION include/uuid)
     install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets)
     install(EXPORT ${PROJECT_NAME}-targets
             DESTINATION lib/cmake/${PROJECT_NAME})


### PR DESCRIPTION
Changes installation to copy the `uuid.h` file to a directory named `uuid` inside `/usr/include`, i.e. install it to `/usr/include/uuid/uuid.h`. This is actually [the behavior expected by `FindLibuuid.cmake`](https://github.com/mariusbancila/stduuid/blob/3afe7193facd5d674de709fccc44d5055e144d7a/cmake/FindLibuuid.cmake#L1) so it also may be considered a bug fix.

Installing library headers in a package-specific directory instead of the root of `/usr/include` reduces naming conflicts (in Arch Linux, for example, 53 packages install a file named `uuid.h`), simplifies maintenance, provides clearer organization, and makes it easier to uninstall libraries.