### PR TITLE
[brief] Make the installed version number match stduuid version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,12 +63,12 @@ if(UUID_ENABLE_INSTALL)
             "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
             INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
     write_basic_package_version_file(
-            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
             VERSION "1.2.3"
             COMPATIBILITY AnyNewerVersion)
     install(FILES
             "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
             "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindLibuuid.cmake"
             DESTINATION lib/cmake/${PROJECT_NAME})
     export(EXPORT ${PROJECT_NAME}-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(UUID_ENABLE_INSTALL)
             INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
     write_basic_package_version_file(
             "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-version.cmake"
-            VERSION "1.0"
+            VERSION "1.2.3"
             COMPATIBILITY AnyNewerVersion)
     install(FILES
             "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"


### PR DESCRIPTION
[detailed]
- Installed version was still at 1.0 even though library is now at 1.2.3.
- This is to keep things up-to-date and to allow users to link against specific versions of stduuid via `find_package(stduuid 1.2.3)`