### PR TITLE
Fix build with GCC10

### DIFF
--- a/include/uuid.h
+++ b/include/uuid.h
@@ -19,7 +19,7 @@
 
 #ifdef __cplusplus
 
-#  if (__cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#  if (__cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L) || (defined(__GNUC__) && __GNUC__ == 10 && __cplusplus > 201703L)
 #    define LIBUUID_CPP20_OR_GREATER
 #  endif
 


### PR DESCRIPTION
GCC10 ships with a native C++20 span implementation. However, enabling UUID_USING_CXX20_SPAN in combination with GCC10 and the experimental c++20 support causes a compilation error. This is due to GCC10 sets the __cplusplus to a value strictly greater than 201703L but not to 202002L.

Fixes #80 