### PR TITLE
Fix CMakeLists.txt using CMAKE_SOURCE_DIR instead of CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 endif()
 
 project(stduuid CXX)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(UUID_BUILD_TESTS "Build the unit tests" ${UUID_MAIN_PROJECT})
 option(UUID_SYSTEM_GENERATOR "Enable operating system uuid generator" OFF)


### PR DESCRIPTION
`CMakeLists.txt` used to incorrectly use `CMAKE_SOURCE_DIR` instead of `CMAKE_CURRENT_SOURCE_DIR`  to point to the `cmake` subfolder.

This notably prevented projects using CMake to include this lib to access `FindLibuuid`. 
This PR shoud fix things like https://github.com/mariusbancila/stduuid/issues/77 
